### PR TITLE
Update to Adobe Creative Suite 2018 sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ The XML source files can be found in the following locations on Mac OS X:
   
 On Windows:
 
-  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
-  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
-  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
+  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC\CommonFiles`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC\illustrator 2018`
+  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC\photoshop`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
 
 # License #

--- a/README.md
+++ b/README.md
@@ -55,18 +55,16 @@ Now open your browser [here](http://localhost:8080).
 The XML source files can be found in the following locations on Mac OS X:
 
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/CommonFiles`
-  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator`
+  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator 2018`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/photoshop`
   - `~/Library/Preferences/ExtendScript Toolkit/4.0/`
   
 On Windows:
 
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
-  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/illustrator`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
-  
-If you have a 64-Bit version of the Adobe program installed, go to `C:\Program Files\` instead of `C:\Program Files (x86)\`.
 
 # License #
 

--- a/src/findxml
+++ b/src/findxml
@@ -9,7 +9,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p ${__dir}/../xml/source/
 
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator\ 2018/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 

--- a/src/findxml
+++ b/src/findxml
@@ -9,7 +9,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p ${__dir}/../xml/source/
 
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator/omv.xml ${__dir}/../xml/source/illustrator.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -31,9 +31,9 @@ html(lang='en', ng-app='esDocApp')
 
           div.form-group
             select.form-control(ng-model='namespace', ng-change='update()')
-              option(value='InDesign', selected=true) InDesign CC 2014
-              option(value='Illustrator') Illustrator CC 2014
-              option(value='Photoshop') Photoshop CC 2014
+              option(value='InDesign', selected=true) InDesign CC 2018 (13.1)
+              option(value='Illustrator') Illustrator 22
+              option(value='Photoshop') Photoshop CC 2015.5
               option(value='Javascript') Javascript
               option(value='ScriptUI') ScriptUI
 

--- a/xml/map.json
+++ b/xml/map.json
@@ -1,6 +1,6 @@
 {
   "illustrator": "Illustrator",
-  "indesign-10.064$10.0": "InDesign",
+  "indesign-13.064$13.1": "InDesign",
   "javascript": "Javascript",
   "photoshop": "Photoshop",
   "scriptui": "ScriptUI"


### PR DESCRIPTION
The documentation processor currently expects Adobe Creative Suite 2014 source files. This should be updated.

I suggest adjusting the API selection dropdown in order to reflect the naming and versioning of the orignal Object Model Viewer.