### PR TITLE
Support document generation on the Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build automatically (only works on OSX):
 
     $ npm run build
 
-The docs will be compiled to `public/`. OMV XML files will automatically be found, if you're building on Windows you will need to locate these yourself.
+The docs will be compiled to `public/`. OMV XML files will automatically be found.
 
 ## Development guide ##
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,16 @@ Now open your browser [here](http://localhost:8080).
 The XML source files can be found in the following locations on Mac OS X:
 
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/CommonFiles`
-  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator`
+  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator 2018`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/photoshop`
   - `~/Library/Preferences/ExtendScript Toolkit/4.0/`
   
 On Windows:
 
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
-  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/illustrator`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
-  
-If you have a 64-Bit version of the Adobe program installed, go to `C:\Program Files\` instead of `C:\Program Files (x86)\`.
 
 # License #
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,9 +46,19 @@ gulp.task('static', function() {
 gulp.task('web', ['javascript', 'less', 'templates', 'static']);
 
 gulp.task('xml', function(cb) {
-  execSync('./src/findxml')
-  execSync('./src/xml2json.py')
-  execSync('./src/json2public.py')
+  switch (process.platform) {
+    case 'win32':
+      execSync('.\\src\\findxml.bat')
+      execSync('.\\src\\xml2json.py')
+      execSync('.\\src\\json2public.py')
+      break;
+
+    default:
+      execSync('./src/findxml')
+      execSync('./src/xml2json.py')
+      execSync('./src/json2public.py')
+      break;
+  }
 
   cb();
 });

--- a/src/findxml
+++ b/src/findxml
@@ -9,7 +9,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p ${__dir}/../xml/source/
 
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator/omv.xml ${__dir}/../xml/source/illustrator.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -7,7 +7,7 @@ set __xmlsource=%__dir:~0,-4%xml\source\
 
 mkdir %__xmlsource% 2> nul
 
-copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*" %__xmlsource%
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*.xml" %__xmlsource%
 if ERRORLEVEL 1 goto copy
 copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\omv.xml" %__xmlsource%illustrator.xml
 if ERRORLEVEL 1 goto copy

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -1,0 +1,26 @@
+@echo off
+
+setlocal enableextensions
+
+set __dir=%~dp0
+set __xmlsource=%__dir:~0,-4%xml\source\
+
+mkdir %__xmlsource% 2> nul
+
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*" %__xmlsource%
+if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\omv.xml" %__xmlsource%illustrator.xml
+if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC/photoshop\omv.xml" %__xmlsource%photoshop.xml
+if ERRORLEVEL 1 goto copy
+copy /y "%APPDATA%\Adobe\ExtendScript Toolkit\4.0\omv*.xml" %__xmlsource%
+if %ERRORLEVEL% lss 1 goto end
+
+:copy
+echo Unable to copy files 1>&2
+endlocal
+exit /b 1
+
+:end
+endlocal
+exit /b 0

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -31,9 +31,9 @@ html(lang='en', ng-app='esDocApp')
 
           div.form-group
             select.form-control(ng-model='namespace', ng-change='update()')
-              option(value='InDesign', selected=true) InDesign CC 2014
-              option(value='Illustrator') Illustrator CC 2014
-              option(value='Photoshop') Photoshop CC 2014
+              option(value='InDesign', selected=true) InDesign CC 2018 (13.1)
+              option(value='Illustrator') Illustrator 22
+              option(value='Photoshop') Photoshop CC 2015.5
               option(value='Javascript') Javascript
               option(value='ScriptUI') ScriptUI
 

--- a/xml/map.json
+++ b/xml/map.json
@@ -1,6 +1,6 @@
 {
   "illustrator": "Illustrator",
-  "indesign-10.064$10.0": "InDesign",
+  "indesign-13.064$13.1": "InDesign",
   "javascript": "Javascript",
   "photoshop": "Photoshop",
   "scriptui": "ScriptUI"


### PR DESCRIPTION
The tooling is currently limited in that the automatic source file collection routine only works on MacOS systems. This pull request suggests adding the same tooling for the Windows platform.

Sorry for the dependency: In order to properly test this I felt kind of unwilling to roll my installation back to (Creative Cloud software releases) 2014 and therefore implemented this on top of #21.