### PR TITLE
Add Bridge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains the source code for building the documentation system. If you
 
   - Python3
   - Node.js and npm
-  - Adobe InDesign/Illustrator/Photoshop and ExtendScript Toolkit for XML source files
+  - Adobe InDesign/Illustrator/Photoshop/Bridge and ExtendScript Toolkit for XML source files
 
 ## Generating the documentation ##
 
@@ -57,6 +57,7 @@ The XML source files can be found in the following locations on Mac OS X:
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/CommonFiles`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator 2018`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/photoshop`
+  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Adobe Bridge CC 2018`
   - `~/Library/Preferences/ExtendScript Toolkit/4.0/`
   
 On Windows:
@@ -64,6 +65,7 @@ On Windows:
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
   - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC\Adobe Bridge CC 2018`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
 
 # License #

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build automatically (only works on OSX):
 
     $ npm run build
 
-The docs will be compiled to `public/`. OMV XML files will automatically be found, if you're building on Windows you will need to locate these yourself.
+The docs will be compiled to `public/`. OMV XML files will automatically be found.
 
 ## Development guide ##
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,16 @@ Now open your browser [here](http://localhost:8080).
 The XML source files can be found in the following locations on Mac OS X:
 
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/CommonFiles`
-  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator`
+  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator 2018`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/photoshop`
   - `~/Library/Preferences/ExtendScript Toolkit/4.0/`
   
 On Windows:
 
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
-  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/illustrator`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
-  
-If you have a 64-Bit version of the Adobe program installed, go to `C:\Program Files\` instead of `C:\Program Files (x86)\`.
 
 # License #
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,9 +46,19 @@ gulp.task('static', function() {
 gulp.task('web', ['javascript', 'less', 'templates', 'static']);
 
 gulp.task('xml', function(cb) {
-  execSync('./src/findxml')
-  execSync('./src/xml2json.py')
-  execSync('./src/json2public.py')
+  switch (process.platform) {
+    case 'win32':
+      execSync('.\\src\\findxml.bat')
+      execSync('.\\src\\xml2json.py')
+      execSync('.\\src\\json2public.py')
+      break;
+
+    default:
+      execSync('./src/findxml')
+      execSync('./src/xml2json.py')
+      execSync('./src/json2public.py')
+      break;
+  }
 
   cb();
 });

--- a/src/findxml
+++ b/src/findxml
@@ -9,7 +9,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p ${__dir}/../xml/source/
 
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator/omv.xml ${__dir}/../xml/source/illustrator.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 

--- a/src/findxml
+++ b/src/findxml
@@ -11,6 +11,7 @@ mkdir -p ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Adobe Bridge CC 2018/omv.xml ${__dir}/../xml/source/bridge.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 
 exit 0

--- a/src/findxml
+++ b/src/findxml
@@ -11,7 +11,7 @@ mkdir -p ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Adobe Bridge CC 2018/omv.xml ${__dir}/../xml/source/bridge.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Adobe\ Bridge\ CC\ 2018/omv.xml ${__dir}/../xml/source/bridge.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 
 exit 0

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -7,7 +7,7 @@ set __xmlsource=%__dir:~0,-4%xml\source\
 
 mkdir %__xmlsource% 2> nul
 
-copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*" %__xmlsource%
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*.xml" %__xmlsource%
 if ERRORLEVEL 1 goto copy
 copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\omv.xml" %__xmlsource%illustrator.xml
 if ERRORLEVEL 1 goto copy

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -13,6 +13,8 @@ copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\o
 if ERRORLEVEL 1 goto copy
 copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC/photoshop\omv.xml" %__xmlsource%photoshop.xml
 if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\Adobe Bridge CC 2018\omv.xml" %__xmlsource%bridge.xml
+if ERRORLEVEL 1 goto copy
 copy /y "%APPDATA%\Adobe\ExtendScript Toolkit\4.0\omv*.xml" %__xmlsource%
 if %ERRORLEVEL% lss 1 goto end
 

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -1,0 +1,26 @@
+@echo off
+
+setlocal enableextensions
+
+set __dir=%~dp0
+set __xmlsource=%__dir:~0,-4%xml\source\
+
+mkdir %__xmlsource% 2> nul
+
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*" %__xmlsource%
+if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\omv.xml" %__xmlsource%illustrator.xml
+if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC/photoshop\omv.xml" %__xmlsource%photoshop.xml
+if ERRORLEVEL 1 goto copy
+copy /y "%APPDATA%\Adobe\ExtendScript Toolkit\4.0\omv*.xml" %__xmlsource%
+if %ERRORLEVEL% lss 1 goto end
+
+:copy
+echo Unable to copy files 1>&2
+endlocal
+exit /b 1
+
+:end
+endlocal
+exit /b 0

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -34,6 +34,7 @@ html(lang='en', ng-app='esDocApp')
               option(value='InDesign', selected=true) InDesign CC 2018 (13.1)
               option(value='Illustrator') Illustrator 22
               option(value='Photoshop') Photoshop CC 2015.5
+              option(value='Bridge') Bridge CC 2018
               option(value='Javascript') Javascript
               option(value='ScriptUI') ScriptUI
 

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -31,9 +31,9 @@ html(lang='en', ng-app='esDocApp')
 
           div.form-group
             select.form-control(ng-model='namespace', ng-change='update()')
-              option(value='InDesign', selected=true) InDesign CC 2014
-              option(value='Illustrator') Illustrator CC 2014
-              option(value='Photoshop') Photoshop CC 2014
+              option(value='InDesign', selected=true) InDesign CC 2018 (13.1)
+              option(value='Illustrator') Illustrator 22
+              option(value='Photoshop') Photoshop CC 2015.5
               option(value='Javascript') Javascript
               option(value='ScriptUI') ScriptUI
 

--- a/src/xml2json.py
+++ b/src/xml2json.py
@@ -8,7 +8,7 @@ def _decode_property(property_xml):
   data = {
     'name': property_xml.attrib['name'],
     'readonly': 'rwaccess' in property_xml.attrib and property_xml.attrib['rwaccess'] == 'readonly',
-    'type': _fix_type(property_xml.find('./datatype/type').text),
+    'type': _fix_type(property_xml.find('./datatype/type')),
     'array': property_xml.find('./datatype/array') is not None,
   }
 
@@ -23,7 +23,7 @@ def _decode_property(property_xml):
 def _decode_parameter(parameter_xml):
   data = {
     'name': parameter_xml.attrib['name'],
-    'type': _fix_type(parameter_xml.find('./datatype/type').text),
+    'type': _fix_type(parameter_xml.find('./datatype/type')),
     'array': parameter_xml.find('./datatype/array') is not None,
     'optional': ('optional' in parameter_xml.attrib and parameter_xml.attrib['optional'] == 'true')
   }
@@ -46,12 +46,15 @@ def _decode_method(method_xml):
     data['description'] = method_xml.find('./shortdesc').text
 
   if method_xml.find('./datatype') is not None:
-    data['type'] = _fix_type(method_xml.find('./datatype/type').text)
+    data['type'] = _fix_type(method_xml.find('./datatype/type'))
     data['array'] = method_xml.find('./datatype/array') is not None
 
   return data
 
-def _fix_type(t):
+def _fix_type(t_xml):
+  if t_xml is not None:
+    t = t_xml.text
+
     if t == 'varies=any':
       return 'Mixed'
 
@@ -71,6 +74,7 @@ def _fix_type(t):
       return 'Rectangle'
 
     return t
+  return 'Unspecified'
 
 def convert_xml(xml_path, output):
   name = os.path.basename(xml_path)

--- a/xml/map.json
+++ b/xml/map.json
@@ -1,6 +1,6 @@
 {
   "illustrator": "Illustrator",
-  "indesign-10.064$10.0": "InDesign",
+  "indesign-13.064$13.1": "InDesign",
   "javascript": "Javascript",
   "photoshop": "Photoshop",
   "scriptui": "ScriptUI"

--- a/xml/map.json
+++ b/xml/map.json
@@ -1,4 +1,5 @@
 {
+  "bridge": "Bridge",
   "illustrator": "Illustrator",
   "indesign-13.064$13.1": "InDesign",
   "javascript": "Javascript",


### PR DESCRIPTION
May I suggest to add Adobe Bridge 2018 to the API documentation browser? By adding this API, all most recent API versions as currently documented in Object Model Viewer will be covered.

Bridge contains some deprecated APIs with already partially cleaned up method signature. Processing thus has to be fixed to convert illegal None derefencing to the famous `Unspecified` class.

Builds on #22 (and thus #21) for practical reasons. Could be easily backported.

