### PR TITLE
Extend and fix generated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains the source code for building the documentation system. If you
 
   - Python3
   - Node.js and npm
-  - Adobe InDesign/Illustrator/Photoshop and ExtendScript Toolkit for XML source files
+  - Adobe InDesign/Illustrator/Photoshop/Bridge and ExtendScript Toolkit for XML source files
 
 ## Generating the documentation ##
 
@@ -57,6 +57,7 @@ The XML source files can be found in the following locations on Mac OS X:
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/CommonFiles`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator 2018`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/photoshop`
+  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Adobe Bridge CC 2018`
   - `~/Library/Preferences/ExtendScript Toolkit/4.0/`
   
 On Windows:
@@ -64,6 +65,7 @@ On Windows:
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
   - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC\Adobe Bridge CC 2018`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
 
 # License #

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build automatically (only works on OSX):
 
     $ npm run build
 
-The docs will be compiled to `public/`. OMV XML files will automatically be found, if you're building on Windows you will need to locate these yourself.
+The docs will be compiled to `public/`. OMV XML files will automatically be found.
 
 ## Development guide ##
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,16 @@ Now open your browser [here](http://localhost:8080).
 The XML source files can be found in the following locations on Mac OS X:
 
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/CommonFiles`
-  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator`
+  - `/Library/Application Support/Adobe/Scripting Dictionaries CC/Illustrator 2018`
   - `/Library/Application Support/Adobe/Scripting Dictionaries CC/photoshop`
   - `~/Library/Preferences/ExtendScript Toolkit/4.0/`
   
 On Windows:
 
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/CommonFiles`
-  - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/illustrator`
+  - `C:\Program Files\Common Files\Adobe\Scripting Dictionaries CC/illustrator 2018`
   - `C:\Program Files (x86)\Common Files\Adobe\Scripting Dictionaries CC/photoshop`
   - `C:\Users\<YourUserName>\AppData\Roaming\Adobe\ExtendScript Toolkit\4.0`
-  
-If you have a 64-Bit version of the Adobe program installed, go to `C:\Program Files\` instead of `C:\Program Files (x86)\`.
 
 # License #
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,9 +46,19 @@ gulp.task('static', function() {
 gulp.task('web', ['javascript', 'less', 'templates', 'static']);
 
 gulp.task('xml', function(cb) {
-  execSync('./src/findxml')
-  execSync('./src/xml2json.py')
-  execSync('./src/json2public.py')
+  switch (process.platform) {
+    case 'win32':
+      execSync('.\\src\\findxml.bat')
+      execSync('.\\src\\xml2json.py')
+      execSync('.\\src\\json2public.py')
+      break;
+
+    default:
+      execSync('./src/findxml')
+      execSync('./src/xml2json.py')
+      execSync('./src/json2public.py')
+      break;
+  }
 
   cb();
 });

--- a/src/findxml
+++ b/src/findxml
@@ -9,7 +9,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p ${__dir}/../xml/source/
 
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator/omv.xml ${__dir}/../xml/source/illustrator.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 

--- a/src/findxml
+++ b/src/findxml
@@ -11,6 +11,7 @@ mkdir -p ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Adobe Bridge CC 2018/omv.xml ${__dir}/../xml/source/bridge.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 
 exit 0

--- a/src/findxml
+++ b/src/findxml
@@ -11,7 +11,7 @@ mkdir -p ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/CommonFiles/*.xml ${__dir}/../xml/source/
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Illustrator*/omv.xml ${__dir}/../xml/source/illustrator.xml
 cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/photoshop/omv.xml ${__dir}/../xml/source/photoshop.xml
-cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Adobe Bridge CC 2018/omv.xml ${__dir}/../xml/source/bridge.xml
+cp -f /Library/Application\ Support/Adobe/Scripting\ Dictionaries\ CC/Adobe\ Bridge\ CC\ 2018/omv.xml ${__dir}/../xml/source/bridge.xml
 cp -f ~/Library/Preferences/ExtendScript\ Toolkit/4.0/omv*.xml ${__dir}/../xml/source/
 
 exit 0

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -7,7 +7,7 @@ set __xmlsource=%__dir:~0,-4%xml\source\
 
 mkdir %__xmlsource% 2> nul
 
-copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*" %__xmlsource%
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*.xml" %__xmlsource%
 if ERRORLEVEL 1 goto copy
 copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\omv.xml" %__xmlsource%illustrator.xml
 if ERRORLEVEL 1 goto copy

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -13,6 +13,8 @@ copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\o
 if ERRORLEVEL 1 goto copy
 copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC/photoshop\omv.xml" %__xmlsource%photoshop.xml
 if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\Adobe Bridge CC 2018\omv.xml" %__xmlsource%bridge.xml
+if ERRORLEVEL 1 goto copy
 copy /y "%APPDATA%\Adobe\ExtendScript Toolkit\4.0\omv*.xml" %__xmlsource%
 if %ERRORLEVEL% lss 1 goto end
 

--- a/src/findxml.bat
+++ b/src/findxml.bat
@@ -1,0 +1,26 @@
+@echo off
+
+setlocal enableextensions
+
+set __dir=%~dp0
+set __xmlsource=%__dir:~0,-4%xml\source\
+
+mkdir %__xmlsource% 2> nul
+
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC\CommonFiles\*" %__xmlsource%
+if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles%\Adobe\Scripting Dictionaries CC\illustrator 2018\omv.xml" %__xmlsource%illustrator.xml
+if ERRORLEVEL 1 goto copy
+copy /y "%CommonProgramFiles(x86)%\Adobe\Scripting Dictionaries CC/photoshop\omv.xml" %__xmlsource%photoshop.xml
+if ERRORLEVEL 1 goto copy
+copy /y "%APPDATA%\Adobe\ExtendScript Toolkit\4.0\omv*.xml" %__xmlsource%
+if %ERRORLEVEL% lss 1 goto end
+
+:copy
+echo Unable to copy files 1>&2
+endlocal
+exit /b 1
+
+:end
+endlocal
+exit /b 0

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -34,6 +34,7 @@ html(lang='en', ng-app='esDocApp')
               option(value='InDesign', selected=true) InDesign CC 2018 (13.1)
               option(value='Illustrator') Illustrator 22
               option(value='Photoshop') Photoshop CC 2015.5
+              option(value='Bridge') Bridge CC 2018
               option(value='Javascript') Javascript
               option(value='ScriptUI') ScriptUI
 

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -31,9 +31,9 @@ html(lang='en', ng-app='esDocApp')
 
           div.form-group
             select.form-control(ng-model='namespace', ng-change='update()')
-              option(value='InDesign', selected=true) InDesign CC 2014
-              option(value='Illustrator') Illustrator CC 2014
-              option(value='Photoshop') Photoshop CC 2014
+              option(value='InDesign', selected=true) InDesign CC 2018 (13.1)
+              option(value='Illustrator') Illustrator 22
+              option(value='Photoshop') Photoshop CC 2015.5
               option(value='Javascript') Javascript
               option(value='ScriptUI') ScriptUI
 

--- a/src/templates/templates/class.jade
+++ b/src/templates/templates/class.jade
@@ -16,6 +16,10 @@ header
 section
   p {{ class.description }}
 
+  div(ng-show='class.longdesc !== undefined')
+    hr
+    | {{ class.longdesc }}
+
   div(ng-repeat='(type, data) in class.elements')
     h2(ng-show='(data.properties | filter:elementFilter).length + (data.methods | filter:elementFilter).length > 0')
       | {{ type | titleCase }}
@@ -34,11 +38,18 @@ section
           a(href='#/{{ namespace }}/{{ class.name }}/{{ property.name }}')
             b {{ property.name }}
 
+          span(ng-show='property.value !== undefined')
+            | &#160;&#61; {{ property.value }}
+
           span(class='label label-danger', ng-show='property.readonly') Read only
           span(class='label label-primary') Property
 
         div.panel-body
           | {{ property.description }}
+
+          div(ng-show='property.longdesc !== undefined')
+            hr
+            | {{ property.longdesc }}
 
     div(ng-show='(data.methods | filter:elementFilter).length')
       h3 Methods
@@ -64,6 +75,10 @@ section
         div.panel-body
           | {{ method.description }}
 
+          div(ng-show='method.longdesc !== undefined')
+            hr
+            | {{ method.longdesc }}
+
           div(ng-show='(method.parameters).length')
             hr
 
@@ -80,9 +95,14 @@ section
                   td
                     a(href='#/{{ namespace }}/{{ param.type }}')
                       code {{ param.type }}
-                  td {{ param.name }}
+                  td
+                    | {{ param.name }}
+                    span(ng-show='param.value !== undefined')
+                      | &#160;&#61; {{ param.value }}
                   td
                     span(class='label label-info', ng-show='param.optional') Optional
                     | {{ param.description }}
+                    div(ng-show='param.longdesc !== undefined')
+                      | {{ param.longdesc }}
 
     hr

--- a/src/templates/templates/element.jade
+++ b/src/templates/templates/element.jade
@@ -20,12 +20,18 @@ section
         a(href='#/{{ namespace }}/{{ property.type }}', ng-show='property.type')
           code {{ property.type }}
         b {{ property.name }}
+        span(ng-show='property.value !== undefined')
+          | &#160;&#61; {{ property.value }}
 
         span(class='label label-danger', ng-show='property.readonly') Read only
         span(class='label label-primary') Property
 
       div.panel-body
         | {{ property.description }}
+
+        div(ng-show='property.longdesc !== undefined')
+          hr
+          | {{ property.longdesc }}
 
     div(class='panel panel-default', ng-show='method')
       a(name='{{ method.name }}')
@@ -47,6 +53,10 @@ section
       div.panel-body
         | {{ method.description }}
 
+        div(ng-show='method.longdesc !== undefined')
+          hr
+          | {{ method.longdesc }}
+
         div(ng-show='(method.parameters).length')
           hr
 
@@ -63,7 +73,10 @@ section
                 td
                   a(href='#/{{ namespace }}/{{ param.type }}')
                     code {{ param.type }}
-                td {{ param.name }}
+                td
+                  | {{ param.name }}
+                  span(ng-show='param.value !== undefined')
+                    | &#160;&#61; {{ param.value }}
                 td
                   span(class='label label-info', ng-show='param.optional') Optional
                   | {{ param.description }}

--- a/src/xml2json.py
+++ b/src/xml2json.py
@@ -3,6 +3,17 @@
 import json
 import os
 import xml.etree.ElementTree as etree
+from collections import deque
+
+def _subtree_text(element):
+  if element is None: return ''
+  parts = deque()
+  if element.text is not None: parts.append(element.text)
+  for child in element:
+    parts.append(_subtree_text(child))
+    if child.tail is not None: parts.append(child.tail)
+
+  return "".join(parts)
 
 def _decode_property(property_xml):
   data = {
@@ -13,7 +24,10 @@ def _decode_property(property_xml):
   }
 
   if property_xml.find('./shortdesc') is not None:
-    data['description'] = property_xml.find('./shortdesc').text
+    data['description'] = _subtree_text(property_xml.find('./shortdesc'))
+
+  if property_xml.find('./description') is not None:
+     data['longdesc'] = _subtree_text(property_xml.find('./description'))
 
   if property_xml.find('./datatype/value') is not None:
     data['value'] = property_xml.find('./datatype/value').text
@@ -29,7 +43,10 @@ def _decode_parameter(parameter_xml):
   }
 
   if parameter_xml.find('./shortdesc') is not None:
-    data['description'] = parameter_xml.find('./shortdesc').text
+    data['description'] = _subtree_text(parameter_xml.find('./shortdesc'))
+
+  if parameter_xml.find('./description') is not None:
+     data['longdesc'] = _subtree_text(parameter_xml.find('./description'))
 
   if parameter_xml.find('./datatype/value') is not None:
     data['value'] = parameter_xml.find('./datatype/value').text
@@ -43,7 +60,10 @@ def _decode_method(method_xml):
   }
 
   if method_xml.find('./shortdesc') is not None:
-    data['description'] = method_xml.find('./shortdesc').text
+    data['description'] = _subtree_text(method_xml.find('./shortdesc'))
+
+  if method_xml.find('./description') is not None:
+     data['longdesc'] = _subtree_text(method_xml.find('./description'))
 
   if method_xml.find('./datatype') is not None:
     data['type'] = _fix_type(method_xml.find('./datatype/type'))
@@ -111,6 +131,7 @@ def convert_xml(xml_path, output):
 
   for classdef in classdefs:
     class_properties = classdef.findall('./elements[@type="class"]/property')
+    class_methods = classdef.findall('./elements[@type="class"]/method')
     instance_properties = classdef.findall('./elements[@type="instance"]/property')
     instance_methods = classdef.findall('./elements[@type="instance"]/method')
 
@@ -120,6 +141,7 @@ def convert_xml(xml_path, output):
       'elements': {
         'class': {
           'properties': [_decode_property(x) for x in class_properties],
+          'methods': [_decode_method(x) for x in class_methods],
         },
         'instance': {
           'properties': [_decode_property(x) for x in instance_properties],
@@ -129,12 +151,16 @@ def convert_xml(xml_path, output):
     }
 
     if classdef.find('./shortdesc') is not None:
-      class_info['description'] = classdef.find('./shortdesc').text
+      class_info['description'] = _subtree_text(classdef.find('./shortdesc'))
 
     if classdef.find('./superclass') is not None:
       class_info['superclass'] = classdef.find('./superclass').text
 
+    if classdef.find('./description') is not None:
+      class_info['longdesc'] = _subtree_text(classdef.find('./description'))
+
     search[classdef.attrib['name']]  = [x.attrib['name'] for x in class_properties]
+    search[classdef.attrib['name']] += [x.attrib['name'] for x in class_methods]
     search[classdef.attrib['name']] += [x.attrib['name'] for x in instance_properties]
     search[classdef.attrib['name']] += [x.attrib['name'] for x in instance_methods]
 

--- a/src/xml2json.py
+++ b/src/xml2json.py
@@ -8,7 +8,7 @@ def _decode_property(property_xml):
   data = {
     'name': property_xml.attrib['name'],
     'readonly': 'rwaccess' in property_xml.attrib and property_xml.attrib['rwaccess'] == 'readonly',
-    'type': _fix_type(property_xml.find('./datatype/type').text),
+    'type': _fix_type(property_xml.find('./datatype/type')),
     'array': property_xml.find('./datatype/array') is not None,
   }
 
@@ -23,7 +23,7 @@ def _decode_property(property_xml):
 def _decode_parameter(parameter_xml):
   data = {
     'name': parameter_xml.attrib['name'],
-    'type': _fix_type(parameter_xml.find('./datatype/type').text),
+    'type': _fix_type(parameter_xml.find('./datatype/type')),
     'array': parameter_xml.find('./datatype/array') is not None,
     'optional': ('optional' in parameter_xml.attrib and parameter_xml.attrib['optional'] == 'true')
   }
@@ -46,12 +46,15 @@ def _decode_method(method_xml):
     data['description'] = method_xml.find('./shortdesc').text
 
   if method_xml.find('./datatype') is not None:
-    data['type'] = _fix_type(method_xml.find('./datatype/type').text)
+    data['type'] = _fix_type(method_xml.find('./datatype/type'))
     data['array'] = method_xml.find('./datatype/array') is not None
 
   return data
 
-def _fix_type(t):
+def _fix_type(t_xml):
+  if t_xml is not None:
+    t = t_xml.text
+
     if t == 'varies=any':
       return 'Mixed'
 
@@ -71,6 +74,7 @@ def _fix_type(t):
       return 'Rectangle'
 
     return t
+  return 'Unspecified'
 
 def convert_xml(xml_path, output):
   name = os.path.basename(xml_path)

--- a/src/xml2json.py
+++ b/src/xml2json.py
@@ -132,6 +132,7 @@ def convert_xml(xml_path, output):
   for classdef in classdefs:
     class_properties = classdef.findall('./elements[@type="class"]/property')
     class_methods = classdef.findall('./elements[@type="class"]/method')
+    constructors = classdef.findall('./elements[@type="constructor"]/method')
     instance_properties = classdef.findall('./elements[@type="instance"]/property')
     instance_methods = classdef.findall('./elements[@type="instance"]/method')
 
@@ -142,6 +143,9 @@ def convert_xml(xml_path, output):
         'class': {
           'properties': [_decode_property(x) for x in class_properties],
           'methods': [_decode_method(x) for x in class_methods],
+        },
+        'constructors': {
+          'methods': [_decode_method(x) for x in constructors],
         },
         'instance': {
           'properties': [_decode_property(x) for x in instance_properties],
@@ -161,6 +165,7 @@ def convert_xml(xml_path, output):
 
     search[classdef.attrib['name']]  = [x.attrib['name'] for x in class_properties]
     search[classdef.attrib['name']] += [x.attrib['name'] for x in class_methods]
+    search[classdef.attrib['name']] += [x.attrib['name'] for x in constructors]
     search[classdef.attrib['name']] += [x.attrib['name'] for x in instance_properties]
     search[classdef.attrib['name']] += [x.attrib['name'] for x in instance_methods]
 

--- a/xml/map.json
+++ b/xml/map.json
@@ -1,6 +1,6 @@
 {
   "illustrator": "Illustrator",
-  "indesign-10.064$10.0": "InDesign",
+  "indesign-13.064$13.1": "InDesign",
   "javascript": "Javascript",
   "photoshop": "Photoshop",
   "scriptui": "ScriptUI"

--- a/xml/map.json
+++ b/xml/map.json
@@ -1,4 +1,5 @@
 {
+  "bridge": "Bridge",
   "illustrator": "Illustrator",
   "indesign-13.064$13.1": "InDesign",
   "javascript": "Javascript",


### PR DESCRIPTION
Original documentation containing markup used to be malformed as only text up to the first markup element got rendered.

This pull request fixes this and includes all text subnodes of a documentation description element. Furthermore, we add information that previously used to miss from the output
- Render class method and constructor documentation
- Show constant, initial and default values of properties and parameters
- add long description documentation

Fixes #12.